### PR TITLE
updated postgresql-embedded version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Nina Hanzlikova
+Copyright (c) 2017 Nina Hanzlikova, Gregor Ihmor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,24 +7,19 @@ Installation
 ------------
 Add the following to your `project/plugins.sbt` file:
 ```
-resolvers += Resolver.url("io.nhanzlikova.sbt", url("https://dl.bintray.com/geekity/sbt-plugins/"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.bintrayRepo("geekity", "sbt-plugins")
 
-addSbtPlugin("io.nhanzlikova.sbt" % "sbt-embedded-postgres" % "1.1.0")
+addSbtPlugin("io.nhanzlikova.sbt" % "sbt-embedded-postgres" % "1.2.0")
 ```
 
 Configuration
 -------------
-The following represents an example configuration in `build.sbt` to use [sbt-embedded-postgres](https://github.com/geekity/sbt-embedded-postgres)
-
-To use the postgresql in your project have your tests depend on starting the PostgreSQL server.
+To use the embedded postgres server, just define a dependency on `startPostgres` or `postgresConnectionString`.
+This will make sbt execute `startPostgres` before starting your process. For example:
 ```
-lazy val root = (project in file(".")).enablePlugins(EmbeddedPostgresPlugin)
-
-testOptions in Test <+= postgresTestCleanup // clean up postgresql after tests
-
-test in Test <<= (test in Test).dependsOn(startPostgres)
-
-testOnly in Test <<= (testOnly in Test).dependsOn(startPostgres)
+enablePlugins(EmbeddedPostgresPlugin)
+javaOptions += s"-DDATABASE_URL=${postgresConnectionString.value}"
+postgresSilencer := true
 ```
 
 Configuration options (in `build.sbt`) and their defaults
@@ -38,7 +33,5 @@ postgresVersion := PRODUCTION // IVersion from ru.yandex.qatools.embed.postgresq
 
 If you want to run your build on a CI server, it is advised to let sbt chose a port at random. For this use case is an utility function defined.    
 For example: `postgresPort := EmbeddedPostgresPlugin.getFreePort(25432 to 25532)`.  
-
-The default connection string is `jdbc:postgresql://localhost:25432/database`. It is accessible in sbt with the setting key `postgresConnectionString`. 
 
 The output from the embedded postgres can be suppressed by setting `postgresSilencer := true`.

--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,8 @@ licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
 libraryDependencies ++= {
   Seq(
-    "ru.yandex.qatools.embed" % "postgresql-embedded" % "1.23",
-    "org.postgresql" % "postgresql" % "9.4.1209" % Test,
+    "ru.yandex.qatools.embed" % "postgresql-embedded" % "2.9",
+    "org.postgresql" % "postgresql" % "42.2.2"  % Test,
     "org.scalatest" %% "scalatest" % "3.0.1" % Test
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 logLevel := Level.Warn
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")

--- a/src/test/scala/io/nhanzlikova/sbt/postgres/EmbeddedPostgresServerSpec.scala
+++ b/src/test/scala/io/nhanzlikova/sbt/postgres/EmbeddedPostgresServerSpec.scala
@@ -1,39 +1,30 @@
 package io.nhanzlikova.sbt.postgres
 
-import java.sql.{DriverManager, Connection}
+import java.sql.Connection
+import java.util.Properties
 
-import org.scalatest.{Matchers, BeforeAndAfter, FlatSpec}
+import org.scalatest.{FlatSpec, Matchers}
 import ru.yandex.qatools.embed.postgresql.distribution.Version.Main.PRODUCTION
 
-class EmbeddedPostgresServerSpec extends FlatSpec with Matchers with BeforeAndAfter {
+class EmbeddedPostgresServerSpec extends FlatSpec with Matchers {
 
   val dbPort = 25432
   val dbName = "testdatabase"
-  val dbUrl = s"jdbc:postgresql://localhost:${dbPort}/${dbName}"
   val username = "admin"
   val password = "admin"
+  val dbUrl = s"jdbc:postgresql://localhost:${dbPort}/${dbName}?user=${username}&password=${password}"
 
   val pg = new EmbeddedPostgresServer("localhost", dbPort, dbName, username, password, PRODUCTION)
 
-  before {
-    pg.start()
-  }
-
-  after {
-    pg.stop()
-  }
-
   "An embedded postgres server" should "create a default database" in {
-    val conn: Connection = {
-      DriverManager.getConnection(
-        dbUrl, username, password
-      )
-    }
+    pg.start()
+    val conn: Connection = new org.postgresql.Driver().connect(dbUrl, new Properties())
 
     val query = conn.createStatement().executeQuery("SELECT count(*) FROM pg_database where datname='testdatabase'")
     while (query.next()) query.getInt("count") shouldBe 1
 
     conn.close()
+    pg.stop()
   }
 
 }


### PR DESCRIPTION
Hello Nina,

I've encountered some problems with your plugin and windows. The issue is known in postgresql-embedded and the solution is to update.  See https://github.com/yandex-qatools/postgresql-embedded/issues/81
So I've updated the postgresql-embedded lib to the newest version and the problem is resolved for me.

I also made some small changes to the settings and tasks. `postgresConnectionString` is no longer a setting, but instead a task and forwards to `startPostgres` which will now return the connection string after starting.

Cheers